### PR TITLE
chore(requirements): ⚓ dont pin pymodbus version

### DIFF
--- a/custom_components/plexlog/manifest.json
+++ b/custom_components/plexlog/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/larszi/home-assistant-plexlog/issues",
   "iot_class": "local_polling",
   "requirements": [
-    "pymodbus==3.8.2"
+    "pymodbus~=3.0"
   ],
   "version": "2.0.2"
 }


### PR DESCRIPTION
HA now requires modbus as well therefore having a requirement for a different version is creating conflicts. Therefor we just ⚓ for the major version.